### PR TITLE
jzintv - disable distcc due to lto crashes on gcc 8 on Buster

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -45,7 +45,7 @@ function build_jzintv() {
     cd jzintv/src
 
     make clean
-    make
+    DISTCC_HOSTS="" make
 
     md_ret_require="$md_build/jzintv/bin/jzintv"
 }


### PR DESCRIPTION
Set DISTCC_HOSTS to empty string for make as is needed with mupen64plus and lr-snes9x. This is an 32bit arm
issue and affects our binary build system which uses distcc with cross compiler on other hosts for performance.