### PR TITLE
openmsx - lock to RELEASE_17_0 as master fails to build on gcc 8.x

### DIFF
--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -13,7 +13,7 @@ rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
-rp_module_repo="git https://github.com/openMSX/openMSX.git master :_get_commit_openmsx"
+rp_module_repo="git https://github.com/openMSX/openMSX.git RELEASE_17_0 :_get_commit_openmsx"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
Looks like they may be using newer C++ features than gcc 8.x provides, but this module is better
fixed to a specific version anyway as it's required workarounds for similar issues in the past.